### PR TITLE
Handle arbitrary grade groups in table

### DIFF
--- a/lib/eligibility_page.dart
+++ b/lib/eligibility_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'api_service.dart';
 import 'models.dart'; // Will use the updated models
@@ -64,8 +65,9 @@ class _EligibilityPageState extends State<EligibilityPage> {
   static const String _autoReloadPrefKey = 'autoReloadEnabled';
 
   bool _eventHasSplitGradeAwards = false;
-  bool _isMobileViewEnabled = false; 
+  bool _isMobileViewEnabled = false;
   static const String _mobileViewPrefKey = 'mobileViewEnabled';
+  static const bool _debugEligibility = kDebugMode;
 
 
   @override
@@ -327,6 +329,9 @@ class _EligibilityPageState extends State<EligibilityPage> {
         }
 
         detectedSplitAwards = gradeAwardHits.length >= 2;
+        if (_debugEligibility) {
+          debugPrint('Award scan: hits=$gradeAwardHits => split=$detectedSplitAwards');
+        }
       }
       if(!mounted) return;
       setState(() {
@@ -481,6 +486,9 @@ class _EligibilityPageState extends State<EligibilityPage> {
       }
     }
 
+    if (_debugEligibility) {
+      debugPrint('Contexts computed: qualifier=${gradeQualifierRankingsMap.keys} skills=${gradeSkillsRankingsMap.keys} progOnly=${gradeProgrammingOnlyRankingsMap.keys}');
+    }
 
     return teams.map((team) {
       final RawSkill? bestProgRun = bestProgrammingRuns[team.id];
@@ -573,6 +581,14 @@ class _EligibilityPageState extends State<EligibilityPage> {
                         (_programRules!.requiresProgrammingSkills ? (teamProgrammingScore > 0) : true) &&
                         (_programRules!.requiresDriverSkills ? (teamDriverScore > 0) : true);
 
+      if (_debugEligibility) {
+        debugPrint(
+          'Team ${team.number} ${team.grade} -> qualRank=$displayQualRank '
+          '(cutoff $qualCutoffValue) skillsRank=$displaySkillsRank '
+          '(cutoff $skillsCutoffValue) progOnlyRank=$teamProgrammingOnlyRank '
+          '(cutoff $programmingOnlyRankCutoffValue) eligible=$isEligible');
+      }
+
       return TeamSkills(
         team: team,
         qualifierRank: displayQualRank,
@@ -613,7 +629,7 @@ class _EligibilityPageState extends State<EligibilityPage> {
     int qualCutoffRankDisplay;
     int skillsCutoffRankDisplay; 
 
-    if (isCombinedDivisionEvent || gradeLevelContext == null) { 
+    if (isCombinedDivisionEvent || gradeLevelContext == null) {
       final totalRankedTeamsInQualifiers = rawRankings.where((r)=>r.rank > 0).length;
       qualCutoffRankDisplay = max(1, applyProgramSpecificRounding(totalRankedTeamsInQualifiers * eligibilityThreshold, _selectedProgram!));
       skillsCutoffRankDisplay = max(1, applyProgramSpecificRounding(totalRankedTeamsInQualifiers * eligibilityThreshold, _selectedProgram!));
@@ -626,6 +642,10 @@ class _EligibilityPageState extends State<EligibilityPage> {
       }).length;
       qualCutoffRankDisplay = max(1, applyProgramSpecificRounding(gradeSpecificRankedTeamsInQualifiers * eligibilityThreshold, _selectedProgram!));
       skillsCutoffRankDisplay = max(1, applyProgramSpecificRounding(gradeSpecificRankedTeamsInQualifiers * eligibilityThreshold, _selectedProgram!));
+    }
+
+    if (_debugEligibility) {
+      debugPrint('Summary(${gradeLevelContext ?? "overall"}): qualCutoff=$qualCutoffRankDisplay skillsCutoff=$skillsCutoffRankDisplay eligible=${recordsForSummary.where((ts)=>ts.eligible).length}/${recordsForSummary.length}');
     }
 
     final eligibleTeamNumbers = recordsForSummary.where((ts) => ts.eligible).map((ts) => ts.team.number).toList();
@@ -848,6 +868,10 @@ class _EligibilityPageState extends State<EligibilityPage> {
       if (ia != ib) return ia.compareTo(ib);
       return a.compareTo(b);
     });
+
+    if (_debugEligibility) {
+      debugPrint('Grade groups: ${orderedGradeKeys.map((k)=>"$k:${gradeGroups[k]!.length}").join(', ')} others=${otherTeamsDesktop.length}');
+    }
 
     if (_isMobileViewEnabled) {
       // Basic error/empty states for mobile

--- a/lib/eligibility_page.dart
+++ b/lib/eligibility_page.dart
@@ -308,9 +308,10 @@ class _EligibilityPageState extends State<EligibilityPage> {
       if (_programRules!.hasMiddleSchoolHighSchoolDivisions) {
         String baseAwardNameLower = _selectedProgram!.awardName.toLowerCase();
         List<String> keywords = [
+          baseAwardNameLower,
+          baseAwardNameLower.replaceAll('award', '').trim(),
           'excellence',
           'all-around champion',
-          baseAwardNameLower.replaceAll('award', '').trim(),
         ];
 
         Set<String> gradeAwardHits = {};

--- a/lib/eligibility_page.dart
+++ b/lib/eligibility_page.dart
@@ -304,16 +304,29 @@ class _EligibilityPageState extends State<EligibilityPage> {
 
       bool detectedSplitAwards = false;
       if (_programRules!.hasMiddleSchoolHighSchoolDivisions) {
-          final String baseAwardNameLower = _selectedProgram!.awardName.toLowerCase();
-          final String msAwardPattern = "$baseAwardNameLower - middle school";
-          final String hsAwardPattern = "$baseAwardNameLower - high school";
+        String baseAwardNameLower = _selectedProgram!.awardName.toLowerCase();
+        List<String> keywords = [
+          'excellence',
+          'all-around champion',
+          baseAwardNameLower.replaceAll('award', '').trim(),
+        ];
 
-          bool msAwardFound = awards.any((awardL) => awardL.title.toLowerCase() == msAwardPattern);
-          bool hsAwardFound = awards.any((awardL) => awardL.title.toLowerCase() == hsAwardPattern);
-
-          if (msAwardFound && hsAwardFound) {
-              detectedSplitAwards = true;
+        Set<String> gradeAwardHits = {};
+        for (final awardL in awards) {
+          final lower = awardL.title.toLowerCase();
+          if (!keywords.any((k) => lower.contains(k))) continue;
+          if (lower.contains('elementary school') || RegExp(r'\bes\b').hasMatch(lower)) {
+            gradeAwardHits.add('elementary');
           }
+          if (lower.contains('middle school') || RegExp(r'\bms\b').hasMatch(lower)) {
+            gradeAwardHits.add('middle');
+          }
+          if (lower.contains('high school') || RegExp(r'\bhs\b').hasMatch(lower)) {
+            gradeAwardHits.add('high');
+          }
+        }
+
+        detectedSplitAwards = gradeAwardHits.length >= 2;
       }
       if(!mounted) return;
       setState(() {
@@ -793,15 +806,35 @@ class _EligibilityPageState extends State<EligibilityPage> {
     final List<TeamSkills> eligibleForMobile = processedRecords.where((r) => r.eligible).toList();
     final List<TeamSkills> ineligibleForMobile = processedRecords.where((r) => !r.eligible).toList();
 
-    // Desktop view still uses its own msTeams, hsTeams, otherTeams logic for sections
-    List<TeamSkills> msTeamsDesktop = [], hsTeamsDesktop = [], otherTeamsDesktop = [];
-    if (!isCombinedDivisionEvent) { 
-      msTeamsDesktop = processedRecords.where((r) => r.team.grade.toLowerCase() == 'middle school').toList();
-      hsTeamsDesktop = processedRecords.where((r) => r.team.grade.toLowerCase() == 'high school' || (r.team.grade.isNotEmpty && r.team.grade.toLowerCase() != 'middle school')).toList();
-      otherTeamsDesktop = processedRecords.where((r) => r.team.grade.isEmpty).toList();
+    // Desktop view groupings per grade level
+    Map<String, List<TeamSkills>> gradeGroups = {};
+    List<TeamSkills> otherTeamsDesktop = [];
+    Map<String, String> gradeDisplayNames = {};
+    if (!isCombinedDivisionEvent) {
+      for (var rec in processedRecords) {
+        final grade = rec.team.grade.trim();
+        if (grade.isEmpty) {
+          otherTeamsDesktop.add(rec);
+        } else {
+          final lower = grade.toLowerCase();
+          gradeGroups.putIfAbsent(lower, () => []).add(rec);
+          gradeDisplayNames.putIfAbsent(lower, () => grade);
+        }
+      }
     } else {
       otherTeamsDesktop = processedRecords;
     }
+
+    List<String> orderedGradeKeys = gradeGroups.keys.toList();
+    const gradePriority = ['elementary school', 'middle school', 'high school'];
+    orderedGradeKeys.sort((a, b) {
+      int ia = gradePriority.indexOf(a);
+      int ib = gradePriority.indexOf(b);
+      ia = ia == -1 ? gradePriority.length : ia;
+      ib = ib == -1 ? gradePriority.length : ib;
+      if (ia != ib) return ia.compareTo(ib);
+      return a.compareTo(b);
+    });
 
     if (_isMobileViewEnabled) {
       // Basic error/empty states for mobile
@@ -832,7 +865,7 @@ class _EligibilityPageState extends State<EligibilityPage> {
       );
     }
 
-    // --- Desktop Table View (uses msTeamsDesktop, hsTeamsDesktop, otherTeamsDesktop) ---
+    // --- Desktop Table View (gradeGroups + uncategorized teams) ---
     return Column( 
       children: [
         // ... (desktop error and no data messages remain the same, using processedRecords for its isEmpty check)
@@ -861,20 +894,17 @@ class _EligibilityPageState extends State<EligibilityPage> {
             _buildSummaryWidget(null),
             _buildTableForRecordsList(otherTeamsDesktop),
           ] else ...[
-            // Desktop still shows potentially empty sections if no filters active
-            if (msTeamsDesktop.isNotEmpty || (otherTeamsDesktop.isEmpty && hsTeamsDesktop.isEmpty && !isSearchFilterActive && !hideNoData && processedRecords.any((r)=>r.team.grade.toLowerCase()=='middle school'))) ...[
-              _tableSectionTitle('Middle School Teams (${msTeamsDesktop.length})'),
-              _buildSummaryWidget('Middle School'),
-              _buildTableForRecordsList(msTeamsDesktop),
-            ],
-            if (hsTeamsDesktop.isNotEmpty || (otherTeamsDesktop.isEmpty && msTeamsDesktop.isEmpty && !isSearchFilterActive && !hideNoData && processedRecords.any((r)=>r.team.grade.toLowerCase()=='high school'))) ...[
-              _tableSectionTitle('High School / Other Teams (${hsTeamsDesktop.length})'),
-               _buildSummaryWidget('High School'),
-              _buildTableForRecordsList(hsTeamsDesktop),
-            ],
-             if (otherTeamsDesktop.isNotEmpty && !isCombinedDivisionEvent) ...[
+            for (final gradeKey in orderedGradeKeys)
+              if (gradeGroups[gradeKey]!.isNotEmpty ||
+                  (otherTeamsDesktop.isEmpty && !isSearchFilterActive && !hideNoData &&
+                   processedRecords.any((r) => r.team.grade.toLowerCase() == gradeKey))) ...[
+                _tableSectionTitle('${gradeDisplayNames[gradeKey]} Teams (${gradeGroups[gradeKey]!.length})'),
+                _buildSummaryWidget(gradeDisplayNames[gradeKey]),
+                _buildTableForRecordsList(gradeGroups[gradeKey]!),
+              ],
+            if (otherTeamsDesktop.isNotEmpty) ...[
               _tableSectionTitle('Uncategorized / Grade Not Specified (${otherTeamsDesktop.length})'),
-               _buildSummaryWidget(null), 
+              _buildSummaryWidget(null),
               _buildTableForRecordsList(otherTeamsDesktop),
             ],
           ]

--- a/lib/eligibility_page.dart
+++ b/lib/eligibility_page.dart
@@ -357,6 +357,19 @@ class _EligibilityPageState extends State<EligibilityPage> {
     return _programRules!.threshold;
   }
 
+  String _canonicalizeGrade(String grade) {
+    String lower = grade.toLowerCase().replaceAll(RegExp(r'\s*\(.*\)'), '').trim();
+    if (lower.isEmpty) return '';
+    if (lower == 'hs' || lower.contains('high school')) return 'high school';
+    if (lower == 'ms' || lower.contains('middle school')) return 'middle school';
+    if (lower == 'es' || lower.contains('elementary')) return 'elementary school';
+    return lower;
+  }
+
+  String _displayGradeName(String canonical) {
+    return canonical.split(' ').map((w) => w.isNotEmpty ? w[0].toUpperCase() + w.substring(1) : '').join(' ');
+  }
+
   List<TeamSkills> get tableRecords {
     if (_programRules == null || teams.isEmpty || _selectedProgram == null) return [];
 
@@ -401,7 +414,7 @@ class _EligibilityPageState extends State<EligibilityPage> {
     final bool checkProgRankRule = _programRules!.requiresRankInPositiveProgrammingSkills;
 
     if (!isCombinedDivisionEvent || checkProgRankRule) { // Precompute if either needs grade-specific data
-      final Set<String> grades = teams.map((t) => t.grade.toLowerCase()).toSet()..removeWhere((g) => g.isEmpty);
+      final Set<String> grades = teams.map((t) => _canonicalizeGrade(t.grade)).toSet()..removeWhere((g) => g.isEmpty);
       List<String> contextsToProcess = [];
       if(isCombinedDivisionEvent && checkProgRankRule) { // Only overall context for prog rank if main event is combined
           contextsToProcess.add("overall_for_prog_rank");
@@ -417,7 +430,7 @@ class _EligibilityPageState extends State<EligibilityPage> {
             gradeQualifierRankingsMap[gradeOrContext] = rawRankings
                 .where((r) {
                   final rTeam = teamMap[r.teamId];
-                  return rTeam != null && rTeam.grade.toLowerCase() == gradeOrContext && r.rank > 0;
+                  return rTeam != null && _canonicalizeGrade(rTeam.grade) == gradeOrContext && r.rank > 0;
                 })
                 .toList()..sort((a, b) => a.rank.compareTo(b.rank));
         }
@@ -426,7 +439,7 @@ class _EligibilityPageState extends State<EligibilityPage> {
         if (!isCombinedDivisionEvent && gradeOrContext != "overall_for_prog_rank" && gradeOrContext != "no_grade_for_prog_rank") {
             List<Map<String,dynamic>> gradeTeamsWithCombinedScores = [];
             for (var teamEntry in teamMap.entries) {
-                if (teamEntry.value.grade.toLowerCase() == gradeOrContext) {
+                if (_canonicalizeGrade(teamEntry.value.grade) == gradeOrContext) {
                     int teamId = teamEntry.key;
                     int combinedScore = (bestProgrammingRuns[teamId]?.score ?? 0) + (bestDriverRuns[teamId]?.score ?? 0);
                     if (combinedScore > 0 || bestProgrammingRuns.containsKey(teamId) || bestDriverRuns.containsKey(teamId) ) {
@@ -449,7 +462,7 @@ class _EligibilityPageState extends State<EligibilityPage> {
                 bool include = false;
                 if (gradeOrContext == "overall_for_prog_rank") include = true;
                 else if (gradeOrContext == "no_grade_for_prog_rank" && teamEntry.value.grade.isEmpty) include = true;
-                else if (teamEntry.value.grade.toLowerCase() == gradeOrContext) include = true;
+                else if (_canonicalizeGrade(teamEntry.value.grade) == gradeOrContext) include = true;
 
                 if (include) {
                     final progRun = bestProgrammingRuns[teamEntry.key];
@@ -515,7 +528,7 @@ class _EligibilityPageState extends State<EligibilityPage> {
         }
 
       } else { // Grade-specific logic
-        final teamGrade = team.grade.toLowerCase();
+        final teamGrade = _canonicalizeGrade(team.grade);
         String gradeContextKey = teamGrade.isNotEmpty ? teamGrade : "no_grade_for_prog_rank";
 
         if (teamGrade.isNotEmpty && gradeQualifierRankingsMap.containsKey(teamGrade)) {
@@ -589,7 +602,7 @@ class _EligibilityPageState extends State<EligibilityPage> {
 
     final recordsForSummary = gradeLevelContext == null
         ? tableRecords
-        : tableRecords.where((ts) => ts.team.grade.toLowerCase() == gradeLevelContext.toLowerCase()).toList();
+        : tableRecords.where((ts) => _canonicalizeGrade(ts.team.grade) == _canonicalizeGrade(gradeLevelContext)).toList();
 
     if (recordsForSummary.isEmpty && gradeLevelContext != null) {
       return Padding(
@@ -605,11 +618,11 @@ class _EligibilityPageState extends State<EligibilityPage> {
       qualCutoffRankDisplay = max(1, applyProgramSpecificRounding(totalRankedTeamsInQualifiers * eligibilityThreshold, _selectedProgram!));
       skillsCutoffRankDisplay = max(1, applyProgramSpecificRounding(totalRankedTeamsInQualifiers * eligibilityThreshold, _selectedProgram!));
     } else {
-      final grade = gradeLevelContext.toLowerCase();
+      final grade = _canonicalizeGrade(gradeLevelContext);
       final gradeSpecificRankedTeamsInQualifiers = rawRankings.where((r) {
-        final teamData = teams.firstWhere((t) => t.id == r.teamId, 
+        final teamData = teams.firstWhere((t) => t.id == r.teamId,
             orElse: () => Team(id: -1, number: '', name: '', grade: '', organization: '', state: '', city: '', country: ''));
-        return teamData.grade.toLowerCase() == grade && r.rank > 0;
+        return _canonicalizeGrade(teamData.grade) == grade && r.rank > 0;
       }).length;
       qualCutoffRankDisplay = max(1, applyProgramSpecificRounding(gradeSpecificRankedTeamsInQualifiers * eligibilityThreshold, _selectedProgram!));
       skillsCutoffRankDisplay = max(1, applyProgramSpecificRounding(gradeSpecificRankedTeamsInQualifiers * eligibilityThreshold, _selectedProgram!));
@@ -812,13 +825,13 @@ class _EligibilityPageState extends State<EligibilityPage> {
     Map<String, String> gradeDisplayNames = {};
     if (!isCombinedDivisionEvent) {
       for (var rec in processedRecords) {
-        final grade = rec.team.grade.trim();
-        if (grade.isEmpty) {
+        final rawGrade = rec.team.grade.trim();
+        if (rawGrade.isEmpty) {
           otherTeamsDesktop.add(rec);
         } else {
-          final lower = grade.toLowerCase();
-          gradeGroups.putIfAbsent(lower, () => []).add(rec);
-          gradeDisplayNames.putIfAbsent(lower, () => grade);
+          final canonical = _canonicalizeGrade(rawGrade);
+          gradeGroups.putIfAbsent(canonical, () => []).add(rec);
+          gradeDisplayNames.putIfAbsent(canonical, () => _displayGradeName(canonical));
         }
       }
     } else {
@@ -897,7 +910,7 @@ class _EligibilityPageState extends State<EligibilityPage> {
             for (final gradeKey in orderedGradeKeys)
               if (gradeGroups[gradeKey]!.isNotEmpty ||
                   (otherTeamsDesktop.isEmpty && !isSearchFilterActive && !hideNoData &&
-                   processedRecords.any((r) => r.team.grade.toLowerCase() == gradeKey))) ...[
+                   processedRecords.any((r) => _canonicalizeGrade(r.team.grade) == gradeKey))) ...[
                 _tableSectionTitle('${gradeDisplayNames[gradeKey]} Teams (${gradeGroups[gradeKey]!.length})'),
                 _buildSummaryWidget(gradeDisplayNames[gradeKey]),
                 _buildTableForRecordsList(gradeGroups[gradeKey]!),


### PR DESCRIPTION
## Summary
- refactor desktop-grade display logic to dynamically create sections for each grade level
- improve split award detection using more flexible matching
- handle elementary vs middle/high when sorting grade sections

## Testing
- `dart format lib/eligibility_page.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685eaac33ad8832390fc92618c2b6b69